### PR TITLE
feature/doc-render

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ gunicorn==20.0.4
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
+requests==2.18.4
 selenium==3.141.0
 Werkzeug==1.0.1

--- a/src/api_dev.py
+++ b/src/api_dev.py
@@ -1,9 +1,17 @@
 # Import Libraries
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template_string
 from scrape_dev import webscrape
+from production.render import docs_html
 
 # Configure as a flask server
 app = Flask(__name__)
+
+# Root endpoints only return README from github repo
+@app.route('/')
+@app.route('/v1')
+def render_docs():
+    return render_template_string(docs_html())
+
 
 # GET /v1/<string: term>/<string: course>/<string: section>
 

--- a/src/production/api.py
+++ b/src/production/api.py
@@ -1,10 +1,17 @@
 # Import Libraries
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template_string
 from .scrape import webscrape  # .scrape for heroku deployment
-import re
+from production.render import docs_html
 
 # Configure as a flask server
 app = Flask(__name__)
+
+# Root endpoints only return README from github repo
+@app.route('/')
+@app.route('/v1')
+def render_docs():
+    return render_template_string(docs_html())
+
 
 # GET /v1/<string: term>/<string: course>/<string: section>
 

--- a/src/production/render.py
+++ b/src/production/render.py
@@ -1,0 +1,13 @@
+# Import Libraries
+import requests
+
+# Renders raw markdown from README.md in github master branch into HTML
+
+
+def docs_html():
+    url = 'https://api.github.com/markdown/raw'
+    md = requests.get(
+        'https://raw.githubusercontent.com/aemmadi/coursebook-api/master/README.md')
+    html = requests.post(url, data=md.text, headers={
+                         'Content-Type': 'text/x-markdown'})
+    return f'<html><head><title>Unofficial API for UT Dallas Coursebook</title></head><body>{html.text}</body></html>'


### PR DESCRIPTION
Root endpoints now render API documentation instead of error message.

`/` and `/v1/`

Fixes #8 